### PR TITLE
Updated styles, added combat -> attacks tab

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -31,6 +31,7 @@
       "action": "Actions",
       "trait": "Traits",
       "nastierSpecial": "Nastier Specials",
+      "attacks": "Basic Attacks",
       "settings": {
         "displayUnequipped": {
           "hint": "Choose whether to display unequipped items on the HUD",

--- a/module.json
+++ b/module.json
@@ -38,7 +38,7 @@
         "type": "system",
         "compatibility": [
           {
-            "minimum": "1.31.1",
+            "minimum": "1.31.0",
             "verified": "1.31.1"
           }
         ]

--- a/module.json
+++ b/module.json
@@ -9,8 +9,7 @@
     }
   ],
   "url": "https://github.com/asacolips-projects/token-action-hud-13th-age",
-  "flags": {},
-  "version": "1.0.2",
+  "version": "1.0.3",
   "compatibility": {
     "minimum": "11",
     "verified": "12.331",
@@ -39,7 +38,7 @@
         "type": "system",
         "compatibility": [
           {
-            "minimum": "1.31.0",
+            "minimum": "1.31.1",
             "verified": "1.31.1"
           }
         ]
@@ -63,9 +62,23 @@
       "optional": []
     }
   },
+  "flags": {
+    "hotReload": {
+      "extensions": [
+        "css",
+        "html",
+        "hbs",
+        "json"
+      ],
+      "paths": [
+        "styles",
+        "languages"
+      ]
+    }
+  },
   "socket": false,
   "manifest": "https://github.com/asacolips-projects/token-action-hud-13th-age/releases/latest/download/module.json",
-  "download": "https://github.com/asacolips-projects/token-action-hud-13th-age/releases/download/1.0.2/module.zip",
+  "download": "https://github.com/asacolips-projects/token-action-hud-13th-age/releases/download/1.0.3/module.zip",
   "readme": "https://github.com/asacolips-projects/token-action-hud-13th-age#readme",
   "protected": false,
   "coreTranslation": false,

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -157,7 +157,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
           let info2 = {};
 
           if (itemData.system.actionType.value) {
-            name = `${'[' + CONFIG.ARCHMAGE.actionTypesShort?.[itemData.system.actionType.value] + '] '}${name}`
             info1 = {
               class: 'action-tag action-power-type',
               text: CONFIG.ARCHMAGE.actionTypesShort?.[itemData.system.actionType.value],

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -57,6 +57,7 @@ export const GROUP = {
   rest: { id: 'rest', name: 'tokenActionHud.template.rest', type: 'system' },
   saves: { id: 'saves', name: 'tokenActionHud.template.saves', type: 'system' },
   
+  attacks: { id: 'attacks', name: 'tokenActionHud.template.attacks', type: 'system' },
   combat: { id: 'combat', name: 'tokenActionHud.combat', type: 'system' },
   utility: { id: 'utility', name: 'tokenActionHud.utility', type: 'system' },
 

--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -71,6 +71,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         id: 'combat',
         name: coreModule.api.Utils.i18n('tokenActionHud13thAge.combat'),
         groups: [
+          { ...groups.attacks, nestId: 'combat_attacks' },
           { ...groups.combat, nestId: 'combat_combat' },
           { ...groups.saves, nestId: 'combat_saves' }
         ]

--- a/styles/token-action-hud-13th-age.css
+++ b/styles/token-action-hud-13th-age.css
@@ -4,3 +4,21 @@
 .tah-tab-group .tah-action-button.daily { background: var(--c-power-daily); }
 .tah-tab-group .tah-action-button.recharge { background: var(--c-power-recharge); }
 .tah-tab-group .tah-action-button.other { background: var(--c-power-other); }
+
+.tah-tab-group {
+  .action-tag {
+    color: white;
+    border: 1px solid rgba(255,255,255,0.5);
+    background: rgba(0,0,0,0.35);
+    padding: 0 4px;
+    border-radius: 4px;
+    font-size: 12px;
+    height: 18px;
+    line-height: 18px;
+  }
+
+  .tah-subtitle-text {
+    background: rgba(0,0,0,0.5);
+    padding: 3px 6px;
+  }
+}


### PR DESCRIPTION
- Updated styles on the HUD to more clearly distinguish supplemental info like power action type or uses remaining.
- Added a new Combat -> Attacks group and filtered basic attacks to appear under it. This may require clearing the Token Action HUD Core cache for your world, which you can find under [FoundryData]/modules/token-action-hud-core/storage/[worldName]

![image](https://github.com/user-attachments/assets/4f95540d-5540-415f-a6c7-d7e45b536674)
![image](https://github.com/user-attachments/assets/1b9628be-1f8a-472d-ad77-bc0d40d2136b)

