### PR TITLE
Add v13 and TAH 2.0.x support

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,9 +11,9 @@
   "url": "https://github.com/asacolips-projects/token-action-hud-13th-age",
   "version": "1.0.4",
   "compatibility": {
-    "minimum": "11",
-    "verified": "12.331",
-    "maximum": "12"
+    "minimum": "13",
+    "verified": "13.351",
+    "maximum": "13"
   },
   "esmodules": [
     "./scripts/init.js"
@@ -38,8 +38,8 @@
         "type": "system",
         "compatibility": [
           {
-            "minimum": "1.31.0",
-            "verified": "1.31.1"
+            "minimum": "1.35.0",
+            "verified": "1.38.1"
           }
         ]
       }
@@ -50,9 +50,8 @@
         "type": "module",
         "compatibility": [
           {
-            "minimum": "1.5.0",
-            "maximum": "1.5",
-            "verified": "1.5.6"
+            "minimum": "2.0.0",
+            "verified": "2.0.16"
           }
         ]
       }

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -122,6 +122,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
           const img = itemData.img
           const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
           const listName = `${actionTypeName ? `${actionTypeName}: ` : ''}${name}`
+          // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
           const encodedValue = [actionTypeId, id].join(this.delimiter)
           const cssClass = itemData.type === 'power'
             ? `power ${Utils.getPowerClasses(itemData.system.powerUsage.value)[0]}`
@@ -150,6 +151,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
           const img = itemData.img
           const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
           const listName = name
+          // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
           const encodedValue = [actionTypeId, id].join(this.delimiter)
           const cssClass = `power ${Utils.getPowerClasses(itemData.system.powerUsage.value)[0]}`
 
@@ -231,6 +233,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
           const img = itemData.img
           const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
           const listName = `${actionTypeName ? `${actionTypeName}: ` : ''}${name}`
+          // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
           const encodedValue = [actionTypeId, id].join(this.delimiter)
 
           return {
@@ -268,6 +271,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const abilityActions = Object.entries(abilityTypes).map((abilityType) => {
         const id = abilityType[0];
         const name = abilityType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = [actionType, id].join(this.delimiter);
         const cssClass = `power recharge`;
         return {
@@ -295,6 +299,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const backgroundActions = Object.entries(backgroundTypes).map((backgroundType) => {
         const id = backgroundType[0];
         const name = backgroundType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = [actionType, id].join(this.delimiter);
         const cssClass = `power other`;
         return {
@@ -315,7 +320,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
     #buildRecovery() {
       if (this.actors.length === 0) return;
-      
+
       // Recoveries
       const recoveryTypes = {
         recovery: { name: coreModule.api.Utils.i18n('ARCHMAGE.CHARACTER.RESOURCES.recovery')}
@@ -324,6 +329,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         const recoveries = this.actor.system.attributes.recoveries;
         const id = recoveryType[0];
         const name = recoveryType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = ['recovery', id].join(this.delimiter);
         const cssClass = `power at-will`;
 
@@ -365,6 +371,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const restActions = Object.entries(restingTypes).map((restingType) => {
         const id = restingType[0];
         const name = restingType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = ['rest', id].join(this.delimiter);
         const cssClass = `power ${restingType[1].usage}`;
         return {
@@ -405,6 +412,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const actions = Object.entries(combatTypes).map((combatType) => {
         const id = combatType[0];
         const name = combatType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = [actionType, id].join(this.delimiter);
         return {
           id,
@@ -424,6 +432,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const saveActions = Object.entries(saveTypes).map((saveType) => {
         const id = saveType[0];
         const name = saveType[1].name;
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = ['saves', id].join(this.delimiter);
         return {
           id,
@@ -432,19 +441,20 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         }
       });
       this.addActions(saveActions, {id: 'saves', type: 'system'});
-      
+
       const groupData = { id: 'combat', type: 'system' };
       this.addActions(actions, groupData);
     }
 
     #buildEffects() {
       if (this.actors.length !== 1) return;
-      
+
       // Conditions.
       const conditionActions = [];
       CONFIG.statusEffects.forEach((statusEffect) => {
         const id = statusEffect.id;
         const name = coreModule.api.Utils.i18n(statusEffect.name);
+        // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
         const encodedValue = ['condition', id].join(this.delimiter);
         const img = statusEffect?.img ?? statusEffect?.icon;
         const tooltip = game.tokenActionHud13thAge.journals.find(j => j.id == statusEffect.journal)?.description ?? coreModule.api.Utils.i18n(name);
@@ -475,6 +485,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
           const id = effect._id;
           const name = effect.name;
+          // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
           const encodedValue = ['effect', id].join(this.delimiter);
           const img = effect?.img ?? effect?.icon;
           const active = !effect.disabled;

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -15,7 +15,7 @@ export const CORE_MODULE = {
 /**
  * Core module version required by the system module
  */
-export const REQUIRED_CORE_MODULE_VERSION = '1.5'
+export const REQUIRED_CORE_MODULE_VERSION = '2.0'
 
 /**
  * Action types
@@ -48,7 +48,7 @@ export const GROUP = {
   action: { id: 'action', name: 'tokenActionHud.template.action', type: 'system' },
   trait: { id: 'trait', name: 'tokenActionHud.template.trait', type: 'system' },
   nastierSpecial: { id: 'nastierSpecial', name: 'tokenActionHud.template.nastierSpecial', type: 'system' },
-  
+
   ability: { id: 'ability', name: 'tokenActionHud.template.ability', type: 'system' },
   background: { id: 'background', name: 'tokenActionHud.template.background', type: 'system' },
   icon: { id: 'icon', name: 'tokenActionHud.template.icon', type: 'system' },
@@ -56,7 +56,7 @@ export const GROUP = {
   recovery: { id: 'recovery', name: 'tokenActionHud.template.recovery', type: 'system' },
   rest: { id: 'rest', name: 'tokenActionHud.template.rest', type: 'system' },
   saves: { id: 'saves', name: 'tokenActionHud.template.saves', type: 'system' },
-  
+
   attacks: { id: 'attacks', name: 'tokenActionHud.template.attacks', type: 'system' },
   combat: { id: 'combat', name: 'tokenActionHud.combat', type: 'system' },
   utility: { id: 'utility', name: 'tokenActionHud.utility', type: 'system' },

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -13,12 +13,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
      * @param {string} encodedValue The encoded value
      */
     async handleActionClick (event, encodedValue) {
+      // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
       const [actionTypeId, actionId] = encodedValue.split('|')
 
       const renderable = ['item']
 
       if (renderable.includes(actionTypeId) && this.isRenderItem()) {
-        return this.doRenderItem(this.actor, actionId)
+        return this.renderItem(this.actor, actionId)
       }
 
       const knownCharacters = ['character', 'npc']
@@ -46,7 +47,9 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
      * @param {object} event        The event
      * @param {string} encodedValue The encoded value
      */
-    async handleActionHover (event, encodedValue) {}
+    async handleActionHover (event, encodedValue) {
+      // @TODO: refactor https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#actiononclick-and-actiononhover
+    }
 
     /**
      * Handle group click


### PR DESCRIPTION
- Updated module to add support for Foundry v13 and Token Action HUD Core 2.0.16.
- Several methods were deprecated in TAH 2.0.0, but they still work. I've left those in for now, but have added TODO comments to revisit them later.